### PR TITLE
Ensure space for null-terminator

### DIFF
--- a/subtitler/subprocess/subprocess_executor_msvc.cpp
+++ b/subtitler/subprocess/subprocess_executor_msvc.cpp
@@ -135,7 +135,7 @@ void SubprocessExecutor::Start() {
 
 std::string SubprocessExecutor::WaitUntilFinished() {
     DWORD amount_read;
-    CHAR buffer[BUFFER_SIZE];
+    CHAR buffer[BUFFER_SIZE + 1]; // Ensure space for null-terminator.
     BOOL success = FALSE;
     std::ostringstream str;
     


### PR DESCRIPTION
Allocate `buffer_size + 1` bytes so there is always room for null-terminator. Related to #6 which was not patched completely in #3 