### PR TITLE
Allow subtitle positions to be edited

### DIFF
--- a/subtitler/cli/commands.h
+++ b/subtitler/cli/commands.h
@@ -68,6 +68,7 @@ private:
     void PrintSubs();
     void AddSub(const std::vector<std::string> &tokens);
     void DeleteSub(const std::vector<std::string> &tokens);
+    void EditSub(const std::vector<std::string> &tokens);
     void Save();
 
     void Quit();

--- a/subtitler/cli/commands_test.cpp
+++ b/subtitler/cli/commands_test.cpp
@@ -382,3 +382,34 @@ TEST_F(CommandsTest, DeleteSubInvalidCommandsPrintErrorMessages) {
     ASSERT_THAT(output.str(), HasSubstr("Missing sequence num. Check help for usage."));
     ASSERT_THAT(output.str(), HasSubstr("Unrecognized token: invalid"));
 }
+
+TEST_F(CommandsTest, EditSubPositionAfterAdding) {
+    std::istringstream input{"add p top-center \nsome subtitle\n\n edit 1 position bottom-left \n printsubs"};
+    std::ostringstream output;
+
+    Commands commands{paths, std::move(ffplay), input, output};
+    commands.MainLoop();
+
+    ASSERT_THAT(output.str(), HasSubstr(
+        "1\n"
+        "00:00:00,000 --> 00:00:05,000\n"
+        "{\\an1} some subtitle\n"
+        "\n"
+    ));
+}
+
+TEST_F(CommandsTest, EditSubPositionInvalidCommandsPrintErrorMessages) {
+    std::istringstream input{"add p tc \nsubtitle\n\n edit \n edit invalid \n"
+                             "edit 1 invalid \n edit 1 p \n edit 1 p invalid \n edit 9999 p middle-center"};
+    std::ostringstream output;
+
+    Commands commands{paths, std::move(ffplay), input, output};
+    commands.MainLoop();
+
+    ASSERT_THAT(output.str(), HasSubstr("Missing sequence num. Check help for usage."));
+    ASSERT_THAT(output.str(), HasSubstr("Unable to parse invalid as sequence number!"));
+    ASSERT_THAT(output.str(), HasSubstr("Unrecognized token: invalid"));
+    ASSERT_THAT(output.str(), HasSubstr("Missing position id. Valid positions are:"));
+    ASSERT_THAT(output.str(), HasSubstr("Unable to edit position of 1. Valid positions are:"));
+    ASSERT_THAT(output.str(), HasSubstr("Unable to edit position of 9999. Valid positions are:"));
+}

--- a/subtitler/srt/subrip_file.cpp
+++ b/subtitler/srt/subrip_file.cpp
@@ -54,13 +54,22 @@ void SubRipFile::AddItem(const SubRipItem &item) {
 }
 
 SubRipItem SubRipFile::RemoveItem(std::size_t sequence_number) {
-    if (sequence_number == 0 || sequence_number > NumItems()) {
+    if (sequence_number <= 0 || sequence_number > NumItems()) {
         throw std::out_of_range("invalid index passed to RemoveItem()");
     }
     auto vector_position = sequence_number - 1;
     auto backup = items_.at(vector_position);
     items_.erase(items_.begin() + vector_position);
     return backup;
+}
+
+void SubRipFile::EditItemPosition(std::size_t sequence_number, const std::string &position) {
+    if (sequence_number <= 0 || sequence_number > NumItems()) {
+        throw std::out_of_range("invalid index passed to EditItemPosition()");
+    }
+    auto vector_position = sequence_number - 1;
+    auto &item = items_.at(vector_position);
+    item.position(position);
 }
 
 

--- a/subtitler/srt/subrip_file.h
+++ b/subtitler/srt/subrip_file.h
@@ -47,6 +47,11 @@ public:
     // Note that indices start at 1, as per SRT file format spec.
     SubRipItem RemoveItem(std::size_t sequence_number);
 
+    // Edits the positioning of an existing SubRipItem.
+    // Reference SubRipItem::pos_to_id for valid positions.
+    // Throws std::out_of_range if invalid sequence or position is provided.
+    void EditItemPosition(std::size_t sequence_number, const std::string &position);
+
 private:
     // SRT items should be ordered by start time to allow for overlapping subtitles.
     std::vector<SubRipItem> items_;

--- a/subtitler/srt/subrip_file_test.cpp
+++ b/subtitler/srt/subrip_file_test.cpp
@@ -138,3 +138,30 @@ TEST_F(SubRipFileTest, ToStreamRangeFilterPreservesSequentialNumbers) {
         output.str()
     );
 }
+
+TEST_F(SubRipFileTest, ChangePosition) {
+    std::ostringstream output;
+    file.EditItemPosition(1, "bottom-left");
+    file.EditItemPosition(3, "top-right");
+    file.ToStream(output);
+
+    ASSERT_EQ(
+        "1\n"
+        "00:00:00,000 --> 00:00:20,000\n"
+        "{\\an1} first\n"
+        "\n"
+        "2\n"
+        "00:00:01,000 --> 00:00:05,000\n"
+        "second\n"
+        "\n"
+        "3\n"
+        "00:00:01,000 --> 00:00:06,000\n"
+        "{\\an9} third\n"
+        "\n"
+        "4\n"
+        "00:00:02,000 --> 00:00:07,000\n"
+        "fourth\n"
+        "\n",
+        output.str()
+    );
+}


### PR DESCRIPTION
Added command `edit <seq_num> position <position>` which allows subtitle position to be changed without having to delete and re-add.

Possibly, this command can be extended in the future to allow for editing of style, text, or time interval. But the last 2 may have some issues.

1. Editing text. The issue is you would need to re-type the entire subtitle, so not much improvement here compared to using `printsubs` to find the sequence number and then `delete <seq_num>` and then redoing it.
2. Editing timestamp. This one is a doozy. Changing the time of a subtitle necessarily also changes it's sequence number. Thus, allowing timestamps to be changed arbitrarily means all sequence numbers may become shuffled. Once a user changes a subtitle to a time interval which does not intersect with their current player position, then they cannot know the new sequence number to identify that subtitle unless they move their player position. The CLI version of this feature is too hard to use, so I don't provide it. Perhaps the eventual GUI version might support this instead.

Also fixes #33 