### PR TITLE
Trimmer does re-encode so it seeks accurately, fixed ffplay paths.

### DIFF
--- a/subtitler/cli/commands_test.cpp
+++ b/subtitler/cli/commands_test.cpp
@@ -80,7 +80,7 @@ TEST_F(CommandsTest, PlayCorrectlySetsStartAndDuration) {
     std::ostringstream output;
     std::ostringstream expected_command;
     expected_command
-        << ffplay_path << " " << video_path << " "
+        << ffplay_path << " \"" << video_path << "\" "
         << "-sn -ss 00:01:30.500 -t 00:00:45.000 -left 0 -top 0 -vf "
         << "\"drawtext=text='%{pts\\:hms}':fontsize=(h/"
            "30):fontcolor=white:box=1:boxcolor=black:fontfile='"
@@ -97,7 +97,7 @@ TEST_F(CommandsTest, PlayCorrectlySetsStartAndDuration_Swapped) {
     std::ostringstream output;
     std::ostringstream expected_command;
     expected_command
-        << ffplay_path << " " << video_path << " "
+        << ffplay_path << " \"" << video_path << "\" "
         << "-sn -ss 01:23:45.000 -t 00:00:45.120 -left 0 -top 0 -vf "
         << "\"drawtext=text='%{pts\\:hms}':fontsize=(h/"
            "30):fontcolor=white:box=1:boxcolor=black:fontfile='"

--- a/subtitler/cli/main_gcc.cpp
+++ b/subtitler/cli/main_gcc.cpp
@@ -113,11 +113,10 @@ int main(int argc, char **argv) {
         }
     }
 
-    // Make sure input file path is wrapped/unwrapped with quotes as needed.
-    // Paths passed to command args should have quotes
-    // Paths opened directly should not have quotes.
+    // Make sure input file path is unwrapped with quotes in case
+    // user included them.
     // TODO: determine whether the FF binaries should have quotes or not.
-    FixInputPath(FLAGS_video_path, /* should_have_quotes= */ true);
+    FixInputPath(FLAGS_video_path, /* should_have_quotes= */ false);
     FixInputPath(FLAGS_output_subtitle_path, /* should_have_quotes= */ false);
 
     // Sanity test writing to output path beforehand so we know it works.

--- a/subtitler/cli/main_msvc.cpp
+++ b/subtitler/cli/main_msvc.cpp
@@ -204,13 +204,6 @@ int main(int argc, char **argv) {
         return 1;
     }
 
-    // Make sure input file path is wrapped/unwrapped with quotes as needed.
-    // Paths passed to command args should have quotes
-    // Paths opened directly should not have quotes.
-    // TODO: determine whether the FF binaries should have quotes or not.
-    FixInputPath(video_path, /* should_have_quotes= */ true);
-    FixInputPath(output_subtitle_path, /* should_have_quotes= */ false);
-
     // Sanity test writing to output path beforehand so we know it works.
     {
         auto path_wrapper = fs::path(fs::u8path(output_subtitle_path));

--- a/subtitler/experimental/trimmer_msvc.cpp
+++ b/subtitler/experimental/trimmer_msvc.cpp
@@ -309,13 +309,21 @@ int main(int argc, char **argv) {
 
         LOG(INFO) << "Start interval";
 
+        // WRT command ordering, checkout
+        // https://github.com/mifi/lossless-cut/pull/13
+        // To get lossless you have to snip on a key frame.
+        // OOTH, if you re-encode you can snip wherever you want.
+        // We choose to re-encode. Slower but very accurate.
         std::ostringstream builder;
-        builder << "ffmpeg -loglevel error -y -ss " << start_str;
+        builder << "ffmpeg -loglevel error";
+        builder << " -i " << video_path;
+        builder << " -y -ss " << start_str;
         if (!end_str.empty()) {
             builder << " -to " << end_str;
         }
-        builder << " -i " << video_path;
-        builder << " -f matroska -c copy ";
+
+        builder << " -f matroska -c:v h264 -c:a aac"
+                << " -avoid_negative_ts make_zero ";
 
         try {
             temp_files.emplace_back(std::make_unique<subtitler::TempFile>(

--- a/subtitler/video/player/ffplay.cpp
+++ b/subtitler/video/player/ffplay.cpp
@@ -116,7 +116,7 @@ void FFPlay::OpenPlayer(const std::string &video_path) {
     }
     std::ostringstream command;
     // TODO: always wrap path in quotes.
-    command << ffplay_path_ << " " << video_path;
+    command << ffplay_path_ << " " << '"' << video_path << '"';
     auto args = BuildArgs();
     for (const auto &arg : args) {
         command << " " << arg;

--- a/subtitler/video/player/ffplay_test.cpp
+++ b/subtitler/video/player/ffplay_test.cpp
@@ -23,7 +23,7 @@ TEST(FFPlayTest, OpenPlayerWithDefaultArgs) {
         // The following must occur in sequence.
         EXPECT_CALL(*mock_executor, CaptureOutput(true)).Times(1);
         EXPECT_CALL(*mock_executor,
-                    SetCommand("ffplay video.mp4 -sn -loglevel error"))
+                    SetCommand("ffplay \"video.mp4\" -sn -loglevel error"))
             .Times(1);
         EXPECT_CALL(*mock_executor, Start()).Times(1);
     }
@@ -37,7 +37,8 @@ TEST(FFPlayTest, OpenPlayerWithScreenDimensionSettings) {
     auto mock_executor = std::make_unique<NiceMock<MockSubprocessExecutor>>();
     EXPECT_CALL(
         *mock_executor,
-        SetCommand("ffplay video.mp4 -x 100 -y 200 -fs -sn -loglevel error"))
+        SetCommand(
+            "ffplay \"video.mp4\" -x 100 -y 200 -fs -sn -loglevel error"))
         .Times(1);
 
     FFPlay ffplay("ffplay", std::move(mock_executor));
@@ -47,7 +48,7 @@ TEST(FFPlayTest, OpenPlayerWithScreenDimensionSettings) {
 TEST(FFPlayTest, OpenPlayerWithDisableStreamSettings) {
     auto mock_executor = std::make_unique<NiceMock<MockSubprocessExecutor>>();
     EXPECT_CALL(*mock_executor,
-                SetCommand("ffplay video.mp4 -vn -an -loglevel error"))
+                SetCommand("ffplay \"video.mp4\" -vn -an -loglevel error"))
         .Times(1);
 
     FFPlay ffplay("ffplay", std::move(mock_executor));
@@ -61,7 +62,7 @@ TEST(FFPlayTest, OpenPlayerWithSeekAndDurationSettings) {
     using namespace std::chrono_literals;
     auto mock_executor = std::make_unique<NiceMock<MockSubprocessExecutor>>();
     EXPECT_CALL(*mock_executor,
-                SetCommand("ffplay video.mp4 -sn -ss 00:00:12.345 -t "
+                SetCommand("ffplay \"video.mp4\" -sn -ss 00:00:12.345 -t "
                            "01:23:45.000 -loglevel error"))
         .Times(1);
 
@@ -75,7 +76,8 @@ TEST(FFPlayTest, OpenPlayerWithPositionSettings) {
     auto mock_executor = std::make_unique<NiceMock<MockSubprocessExecutor>>();
     EXPECT_CALL(
         *mock_executor,
-        SetCommand("ffplay video.mp4 -sn -left 100 -top -200 -loglevel error"))
+        SetCommand(
+            "ffplay \"video.mp4\" -sn -left 100 -top -200 -loglevel error"))
         .Times(1);
 
     FFPlay ffplay("ffplay", std::move(mock_executor));
@@ -86,7 +88,7 @@ TEST(FFPlayTest, OpenPlayerWithTimeStampsEnabled) {
     auto mock_executor = std::make_unique<NiceMock<MockSubprocessExecutor>>();
     EXPECT_CALL(
         *mock_executor,
-        SetCommand("ffplay video.mp4 -sn "
+        SetCommand("ffplay \"video.mp4\" -sn "
                    "-vf \"drawtext=text='%{pts\\:hms}':"
                    "fontsize=(h/30):fontcolor=white:box=1:boxcolor=black:"
                    "fontfile='" +
@@ -101,7 +103,7 @@ TEST(FFPlayTest, OpenPlayerWithTimeStampsEnabled) {
 
 TEST(FFPlayTest, OpenPlayerWithSubtitlesEnabled) {
     auto mock_executor = std::make_unique<NiceMock<MockSubprocessExecutor>>();
-    EXPECT_CALL(*mock_executor, SetCommand("ffplay video.mp4 -sn "
+    EXPECT_CALL(*mock_executor, SetCommand("ffplay \"video.mp4\" -sn "
                                            "-vf \"subtitles='subtitle.srt'\" "
                                            "-loglevel error"))
         .Times(1);
@@ -114,7 +116,7 @@ TEST(FFPlayTest, OpenPlayerWithTimeStampsAndSubtitles) {
     auto mock_executor = std::make_unique<NiceMock<MockSubprocessExecutor>>();
     EXPECT_CALL(
         *mock_executor,
-        SetCommand("ffplay video.mp4 -sn "
+        SetCommand("ffplay \"video.mp4\" -sn "
                    "-vf \"drawtext=text='%{pts\\:hms}':"
                    "fontsize=(h/30):fontcolor=white:box=1:boxcolor=black:"
                    "fontfile='" +


### PR DESCRIPTION
Trimmer shall now re-encode the video output using h264 and audio using aac before producing the result. This is needed so that we can get accurate seek times.

Videos are composed of "Groups of Pictures". A GOP starts with an I-Frame (independent frames), and then several P-Frames (predicted) or B-frames (bidirectional). It is impossible to play a P-Frame on its own, since a P-Frame is based off the difference from the previous frame. That is to say, a video cannot start from a P-Frame! B-Frames work similarly, except they are based off the difference of both the previous and next frames. A video cannot end on a B-Frame!

Consider the following video timeline

```
time      0.0s    0.5s    1.0s    ...
frame     I       P       P       ...
```

Suppose you want to trim your video to start at exactly 0.5. Unfortunately, if you try using `ffmpeg -ss 00:00:00.500 -i video.mp4` then ffmpeg will try to seek to that position based on the video metadata. If the video metadata does not list an I-Frame with pts=0.5s, then it will find the closest seek point. Your closest seek point may even be >10s away!!!

If you instead try `ffmpeg -i video.mp4 -ss 00:00:00.500`, then ffmpeg will DECODE each video frame (not relying on inaccurate metadata) until it reaches your start point. This is slower but more accurate. However, you are STILL affected by the condition that a video cannot start on a P frame, and so ffmpeg will still start the video at 0s.

Yet another thing to consider is audio/video sync. Many videos may not have a I frame until several seconds before/after your seek point. Yet, the audio frames can often be cut very accurately from your seek point. So you may find your audio/video to be out of sync by several seconds, or your audio starts before your video (meaning a few seconds of black screen on your video) and so on.

There are many things which can go wrong. The easiest way is just to transcode the video and audio (that is, re-compute the I, P B frames etc.) Since you have recomputed them, you will be able to start the video wherever you want. Unfortunately, this means much longer processing times, but you no longer have to handle all those edge cases above.

```
ffmpeg -i video.mp4 -ss 00:00:00.5 -c:v h264 -c:a aac -avoid_negative_ts make_zero output.mp4
```
