### PR TITLE
Add linker settings to disable console on windows prod build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,7 @@
 build:vs2019 --cxxopt='/std:c++17' --cxxopt='/WX'
 build:vs2019-asan --cxxopt='/std:c++17' --cxxopt='/WX' --cxxopt='/fsanitize=address' -c dbg
 build:vs2019-prod --cxxopt='/std:c++17' --cxxopt='/DQT_NO_DEBUG_OUTPUT' -c opt
+build:vs2019-prod --linkopt='/SUBSYSTEM:windows' --linkopt='/ENTRY:mainCRTStartup'
 
 build:gcc --cxxopt='-std=c++17' --cxxopt='-Werror' --cxxopt='-fPIC'
 build:gcc-asan --cxxopt='-std=c++17' --cxxopt='-Werror' --cxxopt='-fPIC' -c dbg


### PR DESCRIPTION
As title. See https://stackoverflow.com/questions/2139637/hide-console-of-windows-application.

If we set subsystem to be windows, then by default msvc will set the entry point to be WinMain. Since we want to use main, have to also set `/ENTRY:mainCRTStartup`. https://docs.microsoft.com/en-us/cpp/build/reference/entry-entry-point-symbol?view=msvc-170