### PR TITLE
Add ffmpeg async task to burn subtitles into video

### DIFF
--- a/subtitler/cli/commands.cpp
+++ b/subtitler/cli/commands.cpp
@@ -467,7 +467,7 @@ void Commands::_GeneratePreviewSubs() {
         if (!temp_file_) {
             throw std::runtime_error("Could not make a temp file for the subs");
         }
-        ffplay_->subtitles_path(temp_file_->EscapedFileName());
+        ffplay_->subtitles_path(temp_file_->FileName());
     } else {
         // Also deletes the temp file if it is not null.
         temp_file_.reset();

--- a/subtitler/cli/main_gcc.cpp
+++ b/subtitler/cli/main_gcc.cpp
@@ -96,8 +96,8 @@ int main(int argc, char **argv) {
 
     // If any binary path has spaces, let's make sure they are not
     // interpreted wrongly by wrapping them up with quotes.
-    FixInputPath(FLAGS_ffprobe_path, /* should_have_quotes= */ true);
-    FixInputPath(FLAGS_ffprobe_path, /* should_have_quotes= */ true);
+    FixInputPath(FLAGS_ffplay_path, /* should_have_quotes= */ true);
+    FixInputPath(FLAGS_ffmpeg_path, /* should_have_quotes= */ true);
     FixInputPath(FLAGS_ffprobe_path, /* should_have_quotes= */ true);
 
     try {

--- a/subtitler/cli/main_msvc.cpp
+++ b/subtitler/cli/main_msvc.cpp
@@ -183,8 +183,8 @@ int main(int argc, char **argv) {
 
     // If any binary path has spaces, let's make sure they are not
     // interpreted wrongly by wrapping them up with quotes.
-    FixInputPath(FLAGS_ffprobe_path, /* should_have_quotes= */ true);
-    FixInputPath(FLAGS_ffprobe_path, /* should_have_quotes= */ true);
+    FixInputPath(FLAGS_ffplay_path, /* should_have_quotes= */ true);
+    FixInputPath(FLAGS_ffmpeg_path, /* should_have_quotes= */ true);
     FixInputPath(FLAGS_ffprobe_path, /* should_have_quotes= */ true);
 
     try {

--- a/subtitler/util/temp_file.cpp
+++ b/subtitler/util/temp_file.cpp
@@ -20,23 +20,6 @@ namespace subtitler {
 
 namespace {
 
-// Replaces backwards slashes with forward slashes.
-// Replaces 'C:' with 'C\:'
-// Needed to make windows file paths work with ffmpeg.
-std::string FixPath(const std::string &path) {
-    std::ostringstream output;
-    for (const auto &c : path) {
-        if (c == '\\') {
-            output << '/';
-        } else if (c == ':') {
-            output << "\\:";
-        } else {
-            output << c;
-        }
-    }
-    return output.str();
-}
-
 std::string GetRandomString(int length) {
     std::string random_str;
     random_str.reserve(length);
@@ -99,7 +82,6 @@ TempFile::TempFile(const std::string &data, const fs::path &parent_path,
     CloseHandle(hFile);
 
     temp_file_name_ = random_file_name;
-    escaped_temp_file_name_ = FixPath(temp_file_name_);
 }
 
 #else
@@ -129,7 +111,6 @@ TempFile::TempFile(const std::string &data, const fs::path &parent_path,
     fclose(fp);
 
     temp_file_name_ = random_file_name;
-    escaped_temp_file_name_ = FixPath(temp_file_name_);
 }
 #endif
 

--- a/subtitler/util/temp_file.h
+++ b/subtitler/util/temp_file.h
@@ -30,14 +30,8 @@ class TempFile {
     // Returns the temporary file name.
     std::string FileName() const { return temp_file_name_; }
 
-    // The filename but with windows backslash and colon escaped.
-    // Ex. C:\Windows\fonts becomes C\:/Windows/fonts.
-    // This is needed to pass this filename as an argument to FFPlay etc.
-    std::string EscapedFileName() const { return escaped_temp_file_name_; }
-
   private:
     std::string temp_file_name_;
-    std::string escaped_temp_file_name_;
 };
 
 }  // namespace subtitler

--- a/subtitler/video/player/BUILD
+++ b/subtitler/video/player/BUILD
@@ -9,6 +9,7 @@ cc_library(
     deps = [
         "//subtitler/subprocess:subprocess_executor",
         "//subtitler/util:font_config",
+        "//subtitler/video/util:video_utils",
         "@howard_hinnant_date//:date",
     ],
 )

--- a/subtitler/video/player/ffplay.cpp
+++ b/subtitler/video/player/ffplay.cpp
@@ -7,6 +7,7 @@
 #include "date/date.h"
 #include "subtitler/subprocess/subprocess_executor.h"
 #include "subtitler/util/font_config.h"
+#include "subtitler/video/util/video_utils.h"
 
 namespace subtitler {
 namespace video {
@@ -38,6 +39,11 @@ FFPlay::FFPlay(const std::string &ffplay_path,
 }
 
 FFPlay::~FFPlay() = default;
+
+FFPlay *FFPlay::subtitles_path(const std::string &path) {
+    subtitles_path_ = util::FixPathForFilters(path);
+    return this;
+}
 
 std::vector<std::string> FFPlay::BuildArgs() {
     // Consult https://ffmpeg.org/ffplay.html#toc-Main-options

--- a/subtitler/video/player/ffplay.h
+++ b/subtitler/video/player/ffplay.h
@@ -98,10 +98,7 @@ class FFPlay {
         return this;
     }
 
-    FFPlay* subtitles_path(const std::string& path) {
-        subtitles_path_ = path;
-        return this;
-    }
+    FFPlay* subtitles_path(const std::string& path);
 
   private:
     std::string ffplay_path_;

--- a/subtitler/video/player/ffplay_test.cpp
+++ b/subtitler/video/player/ffplay_test.cpp
@@ -112,6 +112,18 @@ TEST(FFPlayTest, OpenPlayerWithSubtitlesEnabled) {
     ffplay.subtitles_path("subtitle.srt")->OpenPlayer("video.mp4");
 }
 
+TEST(FFPlayTest, OpenPlayerWithWindowsSubtitlePathEnabled) {
+    auto mock_executor = std::make_unique<NiceMock<MockSubprocessExecutor>>();
+    EXPECT_CALL(*mock_executor,
+                SetCommand("ffplay \"video.mp4\" -sn "
+                           "-vf \"subtitles='C\\:/foo/subtitle.srt'\" "
+                           "-loglevel error"))
+        .Times(1);
+
+    FFPlay ffplay("ffplay", std::move(mock_executor));
+    ffplay.subtitles_path("C:\\foo\\subtitle.srt")->OpenPlayer("video.mp4");
+}
+
 TEST(FFPlayTest, OpenPlayerWithTimeStampsAndSubtitles) {
     auto mock_executor = std::make_unique<NiceMock<MockSubprocessExecutor>>();
     EXPECT_CALL(

--- a/subtitler/video/processing/BUILD
+++ b/subtitler/video/processing/BUILD
@@ -8,6 +8,7 @@ cc_library(
     hdrs = ["ffmpeg.h"],
     deps = [
         "//subtitler/subprocess:subprocess_executor",
+        "//subtitler/video/util:video_utils",
     ],
 )
 

--- a/subtitler/video/processing/ffmpeg.cpp
+++ b/subtitler/video/processing/ffmpeg.cpp
@@ -4,6 +4,7 @@
 #include <stdexcept>
 
 #include "subtitler/subprocess/subprocess_executor.h"
+#include "subtitler/video/util/video_utils.h"
 
 namespace subtitler {
 namespace video {
@@ -11,7 +12,9 @@ namespace processing {
 
 FFMpeg::FFMpeg(const std::string& ffmpeg_path,
                std::unique_ptr<subprocess::SubprocessExecutor> executor)
-    : ffmpeg_path_{ffmpeg_path}, executor_{std::move(executor)} {
+    : ffmpeg_path_{ffmpeg_path},
+      executor_{std::move(executor)},
+      is_running_{false} {
     if (ffmpeg_path_.empty()) {
         throw std::invalid_argument{"FFMPEG Path cannot be empty"};
     }
@@ -24,13 +27,17 @@ FFMpeg::FFMpeg(const std::string& ffmpeg_path,
 FFMpeg::~FFMpeg() = default;
 
 std::string FFMpeg::GetVersionInfo() {
+    throwIfRunning();
+
     std::ostringstream stream;
     stream << ffmpeg_path_ << " -version -loglevel error";
     executor_->SetCommand(stream.str());
     executor_->CaptureOutput(true);
     executor_->Start();
+    is_running_ = true;
     // Give generous 5sec timeout.
     auto output = executor_->WaitUntilFinished(5000);
+    is_running_ = false;
     // Check for errors
     if (!output.subproc_stderr.empty()) {
         throw std::runtime_error("Error running ffmpeg: " +
@@ -38,6 +45,46 @@ std::string FFMpeg::GetVersionInfo() {
     }
 
     return output.subproc_stdout;
+}
+
+void FFMpeg::BurnSubtitlesAsync(const std::string& video,
+                                const std::string& subtitles,
+                                const std::string& output) {
+    throwIfRunning();
+
+    std::ostringstream stream;
+    stream << ffmpeg_path_;
+    stream << " -i '" << video << "'";
+    stream << " -vf subtitles='" << util::FixPathForFilters(subtitles) << "'";
+    stream << " '" << output << "'";
+    stream << " -loglevel error -progress pipe:1 -stats_period 5";
+
+    executor_->SetCommand(stream.str());
+    executor_->CaptureOutput(true);
+    executor_->Start();
+    is_running_ = true;
+}
+
+void FFMpeg::WaitForAsyncTask(std::optional<int> timeout_ms) {
+    if (!is_running_) {
+        throw std::runtime_error{
+            "FFMpeg is trying to wait when there are no tasks!"};
+    }
+
+    auto output = executor_->WaitUntilFinished(timeout_ms);
+    is_running_ = false;
+    if (!output.subproc_stderr.empty()) {
+        throw std::runtime_error{"Error running ffmpeg: " +
+                                 output.subproc_stderr};
+    }
+}
+
+void FFMpeg::throwIfRunning() {
+    if (is_running_) {
+        throw std::runtime_error{
+            "You must call FFMpeg::WaitForAsyncTask() before executing another "
+            "task!"};
+    }
 }
 
 }  // namespace processing

--- a/subtitler/video/processing/ffmpeg.h
+++ b/subtitler/video/processing/ffmpeg.h
@@ -2,6 +2,7 @@
 #define SUBTITLER_VIDEO_PROCESSING_FFMPEG_H
 
 #include <memory>
+#include <optional>
 #include <string>
 
 // Forward declaration
@@ -15,17 +16,49 @@ namespace subtitler {
 namespace video {
 namespace processing {
 
+/**
+ * Wrapper class around FFMPEG for long-running tasks which transform videos.
+ */
 class FFMpeg {
   public:
     FFMpeg(const std::string& ffmpeg_path,
            std::unique_ptr<subprocess::SubprocessExecutor> executor);
     ~FFMpeg();
 
+    /**
+     * Returns the version info from the FFMPEG binary. Useful for debugging.
+     *
+     * @return std::string the output of `ffmpeg -version`
+     */
     std::string GetVersionInfo();
+
+    /**
+     * Starts async task to burn subtitles into video, writing result to output.
+     * Caller must eventually call WaitForAsyncTask() after calling this.
+     * Throws runtime_error if another async task is running at the call.
+     *
+     * @param video The path of the input video file.
+     * @param subtitles The path of the input subtitle (.srt) file.
+     * @param output The path of the output file.
+     */
+    void BurnSubtitlesAsync(const std::string& video,
+                            const std::string& subtitles,
+                            const std::string& output);
+
+    /**
+     * Waits (blocks) for the last async task launched to be completed.
+     * Throws runtime_error if no async task is running.
+     *
+     * @param timeout_ms the amount of time to wait before cancelling the task.
+     */
+    void WaitForAsyncTask(std::optional<int> timeout_ms = std::nullopt);
 
   private:
     std::string ffmpeg_path_;
     std::unique_ptr<subprocess::SubprocessExecutor> executor_;
+    bool is_running_;
+
+    void throwIfRunning();
 };
 
 }  // namespace processing

--- a/subtitler/video/processing/ffmpeg_test.cpp
+++ b/subtitler/video/processing/ffmpeg_test.cpp
@@ -14,7 +14,7 @@ using ::testing::InSequence;
 using ::testing::NiceMock;
 using ::testing::Return;
 
-TEST(FFProbeTest, ContainerHasAudioAndVideoStream) {
+TEST(FFMpegTest, GetVersionInfo_ReturnsStdOut) {
     auto mock_executor = std::make_unique<NiceMock<MockSubprocessExecutor>>();
     std::string mock_expected_version = "ffmpeg version 4.4.0 ...";
     {
@@ -31,4 +31,103 @@ TEST(FFProbeTest, ContainerHasAudioAndVideoStream) {
 
     FFMpeg ffmpeg("ffmpeg", std::move(mock_executor));
     ASSERT_EQ(ffmpeg.GetVersionInfo(), mock_expected_version);
+}
+
+TEST(FFMpegTest, GetVersionInfo_ThrowsStdErr) {
+    auto mock_executor = std::make_unique<NiceMock<MockSubprocessExecutor>>();
+    {
+        InSequence sequence;
+        EXPECT_CALL(*mock_executor,
+                    SetCommand("ffmpeg -version -loglevel error"))
+            .Times(1);
+        EXPECT_CALL(*mock_executor, Start()).Times(1);
+        EXPECT_CALL(*mock_executor, WaitUntilFinished(std::optional<int>(5000)))
+            .Times(1)
+            .WillOnce(Return(MockSubprocessExecutor::Output{"", "some error"}));
+    }
+
+    FFMpeg ffmpeg("ffmpeg", std::move(mock_executor));
+    try {
+        ffmpeg.GetVersionInfo();
+        FAIL() << "Expected std::runtime_error";
+    } catch (const std::runtime_error& e) {
+        ASSERT_STREQ(e.what(), "Error running ffmpeg: some error");
+    }
+}
+
+TEST(FFMpegTest, BurnSubtitlesAsync_Success) {
+    auto mock_executor = std::make_unique<NiceMock<MockSubprocessExecutor>>();
+    {
+        InSequence sequence;
+        EXPECT_CALL(
+            *mock_executor,
+            SetCommand(
+                "ffmpeg -i 'video.mp4' -vf subtitles='C\\:/foo/subtitle.srt' "
+                "'output.mp4' -loglevel error -progress pipe:1 -stats_period "
+                "5"))
+            .Times(1);
+        EXPECT_CALL(*mock_executor, Start()).Times(1);
+        EXPECT_CALL(*mock_executor, WaitUntilFinished(std::optional<int>(1000)))
+            .Times(1)
+            .WillOnce(Return(MockSubprocessExecutor::Output{"", ""}));
+    }
+
+    FFMpeg ffmpeg("ffmpeg", std::move(mock_executor));
+    ffmpeg.BurnSubtitlesAsync("video.mp4", "C:\\foo\\subtitle.srt",
+                              "output.mp4");
+    ffmpeg.WaitForAsyncTask(1000);
+}
+
+TEST(FFMpegTest, BurnSubtitlesAsync_TwiceThrowsError) {
+    auto mock_executor = std::make_unique<NiceMock<MockSubprocessExecutor>>();
+    {
+        InSequence sequence;
+        EXPECT_CALL(
+            *mock_executor,
+            SetCommand(
+                "ffmpeg -i 'video.mp4' -vf subtitles='subtitle.srt' "
+                "'output.mp4' -loglevel error -progress pipe:1 -stats_period "
+                "5"))
+            .Times(1);
+        EXPECT_CALL(*mock_executor, Start()).Times(1);
+    }
+
+    FFMpeg ffmpeg("ffmpeg", std::move(mock_executor));
+    ffmpeg.BurnSubtitlesAsync("video.mp4", "subtitle.srt", "output.mp4");
+    try {
+        ffmpeg.BurnSubtitlesAsync("somethingelse.mp4", "foo.srt", "bar.mp4");
+        FAIL() << "Expected std::runtime_error";
+    } catch (const std::runtime_error& e) {
+        ASSERT_STREQ(
+            e.what(),
+            "You must call FFMpeg::WaitForAsyncTask() before executing another "
+            "task!");
+    }
+}
+
+TEST(FFMpegTest, WaitForAsyncTask_ThrowsStdErr) {
+    auto mock_executor = std::make_unique<NiceMock<MockSubprocessExecutor>>();
+    {
+        InSequence sequence;
+        EXPECT_CALL(
+            *mock_executor,
+            SetCommand(
+                "ffmpeg -i 'video.mp4' -vf subtitles='subtitle.srt' "
+                "'output.mp4' -loglevel error -progress pipe:1 -stats_period "
+                "5"))
+            .Times(1);
+        EXPECT_CALL(*mock_executor, Start()).Times(1);
+        EXPECT_CALL(*mock_executor, WaitUntilFinished(std::optional<int>{}))
+            .Times(1)
+            .WillOnce(Return(MockSubprocessExecutor::Output{"", "some error"}));
+    }
+
+    FFMpeg ffmpeg("ffmpeg", std::move(mock_executor));
+    ffmpeg.BurnSubtitlesAsync("video.mp4", "subtitle.srt", "output.mp4");
+    try {
+        ffmpeg.WaitForAsyncTask();
+        FAIL() << "Expected std::runtime_error";
+    } catch (const std::runtime_error& e) {
+        ASSERT_STREQ(e.what(), "Error running ffmpeg: some error");
+    }
 }

--- a/subtitler/video/util/BUILD
+++ b/subtitler/video/util/BUILD
@@ -1,0 +1,10 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+package(default_visibility = ["//subtitler/video:__subpackages__"])
+
+cc_library(
+    name = "video_utils",
+    srcs = ["video_utils.cpp"],
+    hdrs = ["video_utils.h"],
+    deps = [],
+)

--- a/subtitler/video/util/video_utils.cpp
+++ b/subtitler/video/util/video_utils.cpp
@@ -1,0 +1,25 @@
+#include "subtitler/video/util/video_utils.h"
+
+#include <sstream>
+
+namespace subtitler {
+namespace video {
+namespace util {
+
+std::string FixPathForFilters(const std::string &path) {
+    std::ostringstream output;
+    for (const auto &c : path) {
+        if (c == '\\') {
+            output << '/';
+        } else if (c == ':') {
+            output << "\\:";
+        } else {
+            output << c;
+        }
+    }
+    return output.str();
+}
+
+}  // namespace util
+}  // namespace video
+}  // namespace subtitler

--- a/subtitler/video/util/video_utils.h
+++ b/subtitler/video/util/video_utils.h
@@ -1,0 +1,19 @@
+#ifndef SUBTITLER_VIDEO_UTIL_VIDEO_UTILS_H
+#define SUBTITLER_VIDEO_UTIL_VIDEO_UTILS_H
+
+#include <string>
+
+namespace subtitler {
+namespace video {
+namespace util {
+
+// Replaces backwards slashes with forward slashes.
+// Replaces 'C:' with 'C\:'
+// Needed to make windows file paths work with ffmpeg style filters.
+std::string FixPathForFilters(const std::string &path);
+
+}  // namespace util
+}  // namespace video
+}  // namespace subtitler
+
+#endif


### PR DESCRIPTION
Add ffmpeg helper to run task which burns subtitles into a video.

* Refactor out path fixer from temp file to be more generally available to anything in the `video` submodule
* Fix bug in CLI where only ffprobe_path was being fixed... oops!

A follow up PR will bring:
* Add callback to SubprocessExecutor - this will be called new data is written to subprocess' stdout. Up to client to process it. FFMpeg can use this to provide live progress information etc.
* Instead of burning the subtitles, also add remuxing etc.