### PR TITLE
Fix bugs: export segfault, step error, and disable console window

### DIFF
--- a/subtitler/gui/exporting/export_dialog.h
+++ b/subtitler/gui/exporting/export_dialog.h
@@ -38,6 +38,9 @@ class ExportWindow : public QDialog {
     ExportWindow(Inputs inputs, QWidget* parent = Q_NULLPTR);
     ~ExportWindow();
 
+    void accept() override;
+    void reject() override;
+
   public slots:
     void onExport();
     void onProgressUpdate(
@@ -51,6 +54,8 @@ class ExportWindow : public QDialog {
     QPushButton* export_btn_;
     std::unique_ptr<video::processing::FFMpeg> ffmpeg_;
     std::chrono::microseconds video_duration_;
+    // Disables dialog from being closed during export job.
+    bool can_close_;
 };
 
 }  // namespace exporting

--- a/subtitler/gui/timeline/ruler.cpp
+++ b/subtitler/gui/timeline/ruler.cpp
@@ -104,8 +104,10 @@ void Ruler::onMoveIndicator(std::chrono::milliseconds frame_time) {
 }
 
 void Ruler::onStepIndicator(std::chrono::milliseconds delta) {
-    std::chrono::milliseconds new_frame_time = indicator_time_ + delta;
-    onMoveIndicator(new_frame_time);
+    std::chrono::milliseconds new_frame_time =
+        std::max(0ms, indicator_time_ + delta);
+    new_frame_time = std::min(new_frame_time, duration_);
+    onMoveIndicator(std::move(new_frame_time));
     emit userChangedIndicatorTime(indicator_time_);
 }
 

--- a/subtitler/subprocess/subprocess_executor_msvc.cpp
+++ b/subtitler/subprocess/subprocess_executor_msvc.cpp
@@ -193,7 +193,7 @@ void SubprocessExecutor::Start() {
         /* lpProcessAttributes= */ NULL,
         /* lpThreadAttributes= */ NULL,
         /* bInheritHandles= */ TRUE,
-        /* dwCreationFlags= */ 0,
+        /* dwCreationFlags= */ CREATE_NO_WINDOW,
         /* lpEnvironment= */ NULL,
         /* lpCurrentDirectory= */ NULL,
         /* lpStartupInfo= */ &start_info,


### PR DESCRIPTION
Fixes 3 bugs

1. When export dialog is closed by user while the async thread is running, the async thread will try to deliver progress to the dialog. However, the dialog is already deleted, hence invalid memory segfault. Solution is to disable closing of the dialog while the export is still going on. Of course, this does not solve the case where the user force closes the dialog, but that is out of scope for now.
2. Fix issue with forward and back step 5 seconds. If current indicator time is < 5s, then clicking back step button does nothing. Instead we want to set the time to 0. Similarly if indicator is at the end of the video.
3. When ffmpeg is run, a console window is opened. This is dangerous as it will confuse the user, and they may close the window since they don't know what it's for. Then, ffmpeg process will be interrupted. Instead, in SubprocessExecutor we set the window creation flags to hide the console window to prevent confusion.