### PR TITLE
Add a helper for getting optimal downscale settings

### DIFF
--- a/subtitler/video/processing/BUILD
+++ b/subtitler/video/processing/BUILD
@@ -40,3 +40,20 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+cc_library(
+    name = "downscaling",
+    srcs = ["downscaling.cpp"],
+    hdrs = ["downscaling.h"],
+    deps = [],
+)
+
+cc_test(
+    name = "downscaling_test",
+    size = "small",
+    srcs = ["downscaling_test.cpp"],
+    deps = [
+        ":downscaling",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/subtitler/video/processing/downscaling.cpp
+++ b/subtitler/video/processing/downscaling.cpp
@@ -1,0 +1,39 @@
+#include "subtitler/video/processing/downscaling.h"
+
+#include <sstream>
+
+namespace subtitler {
+namespace video {
+namespace processing {
+
+namespace {
+
+constexpr uint64_t ABOVE_1080P_THRESHOLD = 1900 * 1000;
+
+}  // namespace
+
+std::string GetFFMpegScaleFilterRecommendation(
+    const InputVideoScalingInfo input) {
+    uint64_t num_pixels = static_cast<uint64_t>(input.height) *
+                          static_cast<uint64_t>(input.width);
+
+    bool above_1080p = num_pixels > ABOVE_1080P_THRESHOLD;
+    // Add one for double epsilon comparison.
+    bool above_30fps = input.fps > 31;
+
+    std::ostringstream builder;
+    if (above_1080p && above_30fps) {
+        // Set fps to 30, but only if the video is 1080p or above.
+        builder << "fps=30,";
+    }
+    if (above_1080p) {
+        // Scale down to 720p.
+        builder << "scale=-1:720:flags=lanczos";
+    }
+
+    return builder.str();
+}
+
+}  // namespace processing
+}  // namespace video
+}  // namespace subtitler

--- a/subtitler/video/processing/downscaling.h
+++ b/subtitler/video/processing/downscaling.h
@@ -1,0 +1,33 @@
+#ifndef SUBTITLER_VIDEO_PROCESSING_DOWNSCALING_H
+#define SUBTITLER_VIDEO_PROCESSING_DOWNSCALING_H
+
+#include <string>
+
+/**
+ * Implements methods for downscaling videos above 1080p@60fps.
+ * In the GUI, such videos tend to be more latent when presented through
+ * the OpenGL renderer. As a workaround, we can downscale them via
+ * FFMPEG. Roughly, this method allows us to play videos up to ~4k@60fps without
+ * much issue.
+ *
+ */
+
+namespace subtitler {
+namespace video {
+namespace processing {
+
+// Information about the input video.
+struct InputVideoScalingInfo {
+    int height;
+    int width;
+    double fps;
+};
+
+std::string GetFFMpegScaleFilterRecommendation(
+    const InputVideoScalingInfo input);
+
+}  // namespace processing
+}  // namespace video
+}  // namespace subtitler
+
+#endif

--- a/subtitler/video/processing/downscaling.h
+++ b/subtitler/video/processing/downscaling.h
@@ -23,6 +23,8 @@ struct InputVideoScalingInfo {
     double fps;
 };
 
+// Given a video's dimensions and fps, this returns the recommended filters to
+// pass to libav for downscaling.
 std::string GetFFMpegScaleFilterRecommendation(
     const InputVideoScalingInfo input);
 

--- a/subtitler/video/processing/downscaling_test.cpp
+++ b/subtitler/video/processing/downscaling_test.cpp
@@ -1,0 +1,64 @@
+#include "subtitler/video/processing/downscaling.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <string_view>
+
+namespace subtitler {
+namespace video {
+namespace processing {
+
+namespace {
+
+constexpr std::string_view SCALE_FILTER = "scale=-1:720:flags=lanczos";
+constexpr std::string_view FPS_SCALE_FILTER =
+    "fps=30,scale=-1:720:flags=lanczos";
+
+TEST(DownscalingTest, Video_720p_30fps) {
+    struct InputVideoScalingInfo input {
+        /*width=*/1280, /*height=*/720, /*fps=*/30
+    };
+    EXPECT_EQ(GetFFMpegScaleFilterRecommendation(input), "");
+}
+
+TEST(DownscalingTest, Video_720p_60fps) {
+    struct InputVideoScalingInfo input {
+        /*width=*/1280, /*height=*/720, /*fps=*/60
+    };
+    EXPECT_EQ(GetFFMpegScaleFilterRecommendation(input), "");
+}
+
+TEST(DownscalingTest, Video_1080p_30fps) {
+    struct InputVideoScalingInfo input {
+        /*width=*/1920, /*height=*/1080, /*fps=*/30
+    };
+    EXPECT_EQ(GetFFMpegScaleFilterRecommendation(input), SCALE_FILTER);
+}
+
+TEST(DownscalingTest, Video_1080p_60fps) {
+    struct InputVideoScalingInfo input {
+        /*width=*/1920, /*height=*/1080, /*fps=*/60
+    };
+    EXPECT_EQ(GetFFMpegScaleFilterRecommendation(input), FPS_SCALE_FILTER);
+}
+
+TEST(DownscalingTest, Video_4K_30fps) {
+    struct InputVideoScalingInfo input {
+        /*width=*/3840, /*height=*/2160, /*fps=*/30
+    };
+    EXPECT_EQ(GetFFMpegScaleFilterRecommendation(input), SCALE_FILTER);
+}
+
+TEST(DownscalingTest, Video_4K_60fps) {
+    struct InputVideoScalingInfo input {
+        /*width=*/3840, /*height=*/2160, /*fps=*/60
+    };
+    EXPECT_EQ(GetFFMpegScaleFilterRecommendation(input), FPS_SCALE_FILTER);
+}
+
+}  // namespace
+
+}  // namespace processing
+}  // namespace video
+}  // namespace subtitler


### PR DESCRIPTION
 * Implements a helper for getting the recommended downscaling filters to pass to libav.
 * In the GUI, the OpenGL rendering is struggling to output 4k@60fps, so this will help to alleviates the performance bottleneck

Related: #61 