### PR TITLE
Adjust main editor layout

### DIFF
--- a/subtitler/gui/main_window.cpp
+++ b/subtitler/gui/main_window.cpp
@@ -36,7 +36,7 @@ MainWindow::~MainWindow() = default;
 
 MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
     setWindowTitle("SubTite");
-    setMinimumSize(1280, 500);
+    setMinimumSize(1280, 720);
     QWidget *placeholder = new QWidget{this};
     QVBoxLayout *layout = new QVBoxLayout(placeholder);
 
@@ -71,7 +71,9 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
     player_ = std::make_unique<QAVPlayer>();
     player_->setSource(video_file_->fileName(), video_file_.get());
 
-    QWidget *player_controls_placeholder = new QWidget{this};
+    QWidget *interactive_elements_placeholder = new QWidget{this};
+    QWidget *player_controls_placeholder =
+        new QWidget{interactive_elements_placeholder};
     QHBoxLayout *player_controls_layout =
         new QHBoxLayout{player_controls_placeholder};
 
@@ -86,20 +88,25 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
     player_controls_layout->addWidget(play_button);
     player_controls_layout->addWidget(step_forwards);
 
-    timeline::Timer *timer = new timeline::Timer{placeholder};
+    timeline::Timer *timer =
+        new timeline::Timer{interactive_elements_placeholder};
 
     auto duration_us =
         video::util::GetVideoDuration(video_file_->fileName().toStdString());
 
     std::chrono::milliseconds duration =
         std::chrono::duration_cast<std::chrono::milliseconds>(duration_us);
-    timeline::Timeline *timeline =
-        new timeline::Timeline{duration, subtitle_file_, placeholder};
+    timeline::Timeline *timeline = new timeline::Timeline{
+        duration, subtitle_file_, interactive_elements_placeholder};
+
+    QVBoxLayout *interactive_elements_layout =
+        new QVBoxLayout{interactive_elements_placeholder};
+    interactive_elements_layout->addWidget(player_controls_placeholder);
+    interactive_elements_layout->addWidget(timer);
+    interactive_elements_layout->addWidget(timeline);
 
     layout->addWidget(video_renderer_, 60);
-    layout->addWidget(player_controls_placeholder);
-    layout->addWidget(timer);
-    layout->addWidget(timeline);
+    layout->addWidget(interactive_elements_placeholder, 40, Qt::AlignBottom);
 
     setCentralWidget(placeholder);
 

--- a/subtitler/gui/resource/app.qss
+++ b/subtitler/gui/resource/app.qss
@@ -3,7 +3,7 @@
     background: rgb(35, 35, 35);
     color: rgb(145, 145, 145);
     font-family: "Microsoft Yahei";
-    font-size: 15px;
+    font-size: 10pt;
 }
 
 /* QSlider styles */ 

--- a/subtitler/gui/timeline/indicator.cpp
+++ b/subtitler/gui/timeline/indicator.cpp
@@ -8,8 +8,9 @@ Indicator::Indicator(QWidget* parent /* = Q_NULLPTR */) : QLabel(parent) {
     setAttribute(Qt::WA_TranslucentBackground, true);
     setCursor(Qt::SizeHorCursor);
     setPixmap(QPixmap(":/images/indicator"));
-    setMinimumSize(19, 130);
-    move(0, 0);
+    setScaledContents(true);
+    setMinimumSize(19, 200);
+    move(0, 40);
 }
 
 }  // namespace timeline

--- a/subtitler/gui/timeline/ruler.cpp
+++ b/subtitler/gui/timeline/ruler.cpp
@@ -14,7 +14,7 @@
 #include "subtitler/util/duration_format.h"
 
 #define HEADER_HEIGHT 40
-#define BODY_HEIGHT 80
+#define BODY_HEIGHT 200
 #define START_END_PADDING 60
 #define CUT_MARKER_WIDTH 10
 #define TIME_LABEL_OFFSET 10
@@ -60,7 +60,7 @@ Ruler::Ruler(QWidget* parent, std::chrono::milliseconds duration,
     connect(add_subtitle_before_, &QAction::triggered, this,
             &Ruler::onAddSubtitleIntervalBefore);
 
-    resize(rect_width_ + START_END_PADDING, 120);
+    resize(rect_width_ + START_END_PADDING, 220);
 }
 
 Ruler::~Ruler() = default;
@@ -77,7 +77,8 @@ int Ruler::millisecondsToPosition(const std::chrono::milliseconds& ms) {
 
 void Ruler::resetChildren(std::chrono::milliseconds duration) {
     duration_ = duration;
-
+    zoom_level_ = 1;
+    interval_width_ = 130;
     rect_width_ = duration_.count() * interval_width_ / msPerInterval();
     indicator_->move(0, 0);
 
@@ -88,7 +89,7 @@ void Ruler::resetChildren(std::chrono::milliseconds duration) {
 
 void Ruler::LoadSubtitles() {
     const auto [loaded, num_loaded] = subtitle_intervals_->LoadSubripFile(
-        interval_width_, msPerInterval(), HEADER_HEIGHT);
+        interval_width_, msPerInterval(), BODY_HEIGHT / 2);
     if (loaded) {
         emit subtitleFileLoaded(num_loaded);
     }

--- a/subtitler/gui/timeline/subtitle_interval.cpp
+++ b/subtitler/gui/timeline/subtitle_interval.cpp
@@ -9,7 +9,7 @@
 #include "subtitler/srt/subrip_file.h"
 
 #define CUT_MARKER_WIDTH 10
-#define CUT_MARKER_HEIGHT 86
+#define CUT_MARKER_HEIGHT 80
 #define BODY_HEIGHT 80
 
 using namespace std::chrono_literals;

--- a/subtitler/gui/timeline/timeline.cpp
+++ b/subtitler/gui/timeline/timeline.cpp
@@ -14,7 +14,7 @@ namespace timeline {
 Timeline::Timeline(std::chrono::milliseconds duration,
                    const QString& output_srt_file, QWidget* parent)
     : QScrollArea(parent) {
-    setMinimumSize(1280, 150);
+    setMinimumSize(1280, 300);
 
     setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
@@ -22,8 +22,8 @@ Timeline::Timeline(std::chrono::milliseconds duration,
     zoomer_->setMinimumWidth(300);
     addScrollBarWidget(zoomer_, Qt::AlignLeft);
 
-    ruler_ =
-        new Ruler(this, duration, output_srt_file, zoomer_->GetMaxZoomLevel());
+    ruler_ = new Ruler(this, duration, output_srt_file,
+                       zoomer_->GetCurrentZoomLevel());
     setWidget(ruler_);
 
     connect(zoomer_, &Zoomer::zoomIn, ruler_, &Ruler::onZoomIn);

--- a/subtitler/gui/timeline/zoomer.cpp
+++ b/subtitler/gui/timeline/zoomer.cpp
@@ -2,6 +2,7 @@
 
 #include <QHBoxLayout>
 #include <cmath>
+#include <QDebug>
 
 namespace subtitler {
 namespace gui {
@@ -48,9 +49,10 @@ void Zoomer::initializeControls(std::chrono::milliseconds duration) {
     // Double the width
     min_zoom_level_ = 1;
     max_zoom_level_ = computeZoomRange(duration);
+    current_level_ = min_zoom_level_;
 
     zoom_slider_->setRange(min_zoom_level_, max_zoom_level_);
-    zoom_slider_->setSliderPosition(max_zoom_level_);
+    zoom_slider_->setSliderPosition(min_zoom_level_);
 
     zoom_in_ = new QToolButton(this);
     zoom_in_->setIcon(QIcon(":/images/zoomin"));
@@ -69,6 +71,7 @@ void Zoomer::onZoomInClicked(bool checked) {
     int currentValue = zoom_slider_->value();
     if (currentValue > min_zoom_level_) {
         zoom_slider_->setSliderPosition(--currentValue);
+        qDebug() << "zoom: " << currentValue;
         emit zoomIn(currentValue);
     }
 }
@@ -77,6 +80,7 @@ void Zoomer::onZoomOutClicked(bool checked) {
     int currentValue = zoom_slider_->value();
     if (currentValue < max_zoom_level_) {
         zoom_slider_->setSliderPosition(++currentValue);
+        qDebug() << "zoom: " << currentValue;
         emit zoomOut(currentValue);
     }
 }

--- a/subtitler/gui/timeline/zoomer.cpp
+++ b/subtitler/gui/timeline/zoomer.cpp
@@ -2,7 +2,6 @@
 
 #include <QHBoxLayout>
 #include <cmath>
-#include <QDebug>
 
 namespace subtitler {
 namespace gui {
@@ -71,7 +70,6 @@ void Zoomer::onZoomInClicked(bool checked) {
     int currentValue = zoom_slider_->value();
     if (currentValue > min_zoom_level_) {
         zoom_slider_->setSliderPosition(--currentValue);
-        qDebug() << "zoom: " << currentValue;
         emit zoomIn(currentValue);
     }
 }
@@ -80,7 +78,6 @@ void Zoomer::onZoomOutClicked(bool checked) {
     int currentValue = zoom_slider_->value();
     if (currentValue < max_zoom_level_) {
         zoom_slider_->setSliderPosition(++currentValue);
-        qDebug() << "zoom: " << currentValue;
         emit zoomOut(currentValue);
     }
 }

--- a/subtitler/gui/timeline/zoomer.h
+++ b/subtitler/gui/timeline/zoomer.h
@@ -19,7 +19,7 @@ class Zoomer : public QWidget {
     Zoomer(QWidget* parent, std::chrono::milliseconds duration);
     ~Zoomer() = default;
 
-    int GetMaxZoomLevel() const { return max_zoom_level_; };
+    int GetCurrentZoomLevel() const { return current_level_; }
 
   signals:
     void zoomIn(int level);


### PR DESCRIPTION
* Makes the interactive timeline a bit bigger
* Limits the maximum size of the video player. This helps a bit with latency.
* Fixes bug where the timeline is really zoomed out when the application first starts.

Related to #61 