### PR TITLE
Fix OpenGL backwards compatibility with older platforms

### DIFF
--- a/subtitler/gui/video_renderer/opengl_renderer.cpp
+++ b/subtitler/gui/video_renderer/opengl_renderer.cpp
@@ -12,6 +12,7 @@ OpenGLRenderer::OpenGLRenderer(QWidget *parent)
     : QOpenGLWidget(parent), img_{} {}
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
+// Implementation for older platforms that don't support QVideoFrame::image().
 // Reference
 // https://github.com/qt/qtmultimedia/blob/5.12.2/src/multimedia/video/qvideoframe.cpp#L1094
 void OpenGLRenderer::displayFrame(const QVideoFrame &orig_frame) {

--- a/subtitler/gui/video_renderer/opengl_renderer.cpp
+++ b/subtitler/gui/video_renderer/opengl_renderer.cpp
@@ -1,6 +1,7 @@
 #include "subtitler/gui/video_renderer/opengl_renderer.h"
 
 #include <QPainter>
+#include <QtGlobal>
 #include <stdexcept>
 
 namespace subtitler {
@@ -10,10 +11,44 @@ namespace video_renderer {
 OpenGLRenderer::OpenGLRenderer(QWidget *parent)
     : QOpenGLWidget(parent), img_{} {}
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
+// Reference
+// https://github.com/qt/qtmultimedia/blob/5.12.2/src/multimedia/video/qvideoframe.cpp#L1094
+void OpenGLRenderer::displayFrame(const QVideoFrame &orig_frame) {
+    // Since calling QVideoFrame::map is not const,
+    // we remove the const here. I know it's hacky, but the alternative
+    // is to copy the entire frame which is worse on performance.
+    QVideoFrame &frame = const_cast<QVideoFrame &>(orig_frame);
+    if (!frame.isValid() || !frame.map(QAbstractVideoBuffer::ReadOnly)) {
+        return;
+    }
+    QImage::Format imageFormat =
+        QVideoFrame::imageFormatFromPixelFormat(frame.pixelFormat());
+
+    if (imageFormat != QImage::Format_Invalid) {
+        img_ = QImage{frame.bits(), frame.width(), frame.height(),
+                      frame.bytesPerLine(), imageFormat}
+                   .copy();
+    } else if (frame.pixelFormat() == QVideoFrame::Format_Jpeg) {
+        img_.loadFromData(frame.bits(), frame.mappedBytes(), "JPG");
+    } else {
+        frame.unmap();
+        throw std::runtime_error{
+            "Cannot handle this format without more help from Qt internals"};
+    }
+
+    frame.unmap();
+    update();
+}
+
+#else
+// Implementation for newer platforms that support QVideoFrame::image().
 void OpenGLRenderer::displayFrame(const QVideoFrame &orig_frame) {
     img_ = orig_frame.image();
     update();
 }
+
+#endif
 
 /**
  * Given a rectangle with of width and height, return a smaller rectangle which


### PR DESCRIPTION
Fixes issue introduced in #121 that breaks backward compatibility with older platforms (before QT 5.15)

Related to #61 