### PR TITLE
Try cache v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Cache MS Speech SDK
         id: cache-speech-sdk
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: "C:\\Program Files\\PackageManagement\\NuGet\\Packages\\Microsoft.CognitiveServices.Speech.1.22.0"
           key: ${{ runner.os }}-MS-Speech-SDK-Cache
@@ -41,7 +41,7 @@ jobs:
 
       - name: Cache Qt
         id: cache-qt
-        uses: actions/cache@v1  # not v2!
+        uses: actions/cache@v4
         with:
           path: "${{ github.workspace }}/Qt"
           key: ${{ runner.os }}-QtCache
@@ -65,7 +65,7 @@ jobs:
         uses: bazelbuild/setup-bazelisk@v1.0.1
         
       - name: Mount bazel cache  # Optional
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: "~/.cache/bazel"
           key: bazel
@@ -114,7 +114,7 @@ jobs:
           uses: bazelbuild/setup-bazelisk@v1.0.1
           
         - name: Mount bazel cache  # Optional
-          uses: actions/cache@v2
+          uses: actions/cache@v4
           with:
             path: "~/.cache/bazel"
             key: bazel


### PR DESCRIPTION
Apparently cache v1 and v2 are being deprecated. But looks like v4 works. https://github.blog/changelog/2024-09-16-notice-of-upcoming-deprecations-and-changes-in-github-actions-services/